### PR TITLE
Required field enduser_ip added.

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ RegRU.prototype.check = function(dname){
 	return d.promise;
 }
 
-RegRU.prototype.create = function(domain, data, period, nss, org){
+RegRU.prototype.create = function(domain, data, period, ip, nss, org){
 
 	var contacts = {};
 	var d = Q.defer();
@@ -501,6 +501,7 @@ RegRU.prototype.create = function(domain, data, period, nss, org){
 			output_format: "json",
 			lang: "en",
 			domain_name: domain,
+			enduser_ip: ip,
 			period: period,
 			contacts: contacts,
 			//reg_premium: (premiumdomain.indexOf(domain.substr(domain.indexOf("."))) != -1) ? 1 : 0, 

--- a/test/create.js
+++ b/test/create.js
@@ -6,25 +6,25 @@ var regru = new RegRu('test', 'test');
 
 describe('Create ', function(){
 	it("should return 'success' in JSON at domain create .ru", function(){
-		return regru.create("test.ru", testdata.ruDataPerson, 1, ["ns1.staronka.by", "ns2.staronka.by"],false).then(function(res){
+		return regru.create("test.ru", testdata.ruDataPerson, 1, '127.0.0.1', ["ns1.staronka.by", "ns2.staronka.by"],false).then(function(res){
 			JSON.parse(res).should.have.property('result', 'success');
 		}).done();
 	})
 
 	it("should return 'success' in JSON at domain create .ru.net", function(){
-		return regru.create("test.ru.net", testdata.runetDataPerson, 1, ["ns1.staronka.by", "ns2.staronka.by"], false).then(function(res){
+		return regru.create("test.ru.net", testdata.runetDataPerson, 1, '127.0.0.1', ["ns1.staronka.by", "ns2.staronka.by"], false).then(function(res){
 			JSON.parse(res).should.have.property('result', 'success');
 		})
 	})
 
 	/*it("should return 'success' in JSON at domain create .moscow", function(){
-		return regru.create("test.moscow", testdata.moscowDataPerson, 1, ["ns1.staronka.by", "ns2.staronka.by"], false).then(function(res){
+		return regru.create("test.moscow", testdata.moscowDataPerson, 1, '127.0.0.1', ["ns1.staronka.by", "ns2.staronka.by"], false).then(function(res){
 			JSON.parse(res).should.have.property('result', 'success');
 		})
 	})*/
 
 	it("should return 'success' in JSON at domain create .com", function(){
-		return regru.create("test.com", testdata.thematicDataPerson, 1, ["ns1.staronka.by", "ns2.staronka.by"],false).then(function(res){
+		return regru.create("test.com", testdata.thematicDataPerson, 1, '127.0.0.1', ["ns1.staronka.by", "ns2.staronka.by"],false).then(function(res){
 			JSON.parse(res).should.have.property('result', 'success');
 		});
 	})


### PR DESCRIPTION
Hey, I've just find out that as a partner I need to [send ip-address of end user to reg.ru](https://www.reg.ru/support/help/api2#domain_create). Check out my pull request with a small fix.

Thanks in advance!